### PR TITLE
Monster stats: Change "vs" and "vs." to "versus"

### DIFF
--- a/7. Monsters/Monster Stats/Baslisk.md
+++ b/7. Monsters/Monster Stats/Baslisk.md
@@ -20,7 +20,7 @@
 ------
 
 - **Surprise:** Characters surprised by a basilisk meet its gaze.
-- **Petrifying touch:** Anyone touched by a basilisk is turned to stone (**save vs. petrify**).
+- **Petrifying touch:** Anyone touched by a basilisk is turned to stone (**save versus petrify**).
 - **Petrifying gaze:** Anyone meeting a basilisk’s gaze is turned to stone (**save versus petrify**). Unless averting their eyes or using a mirror, characters in melee are affected each round.
 - **Averting eyes:** -4 penalty to-hit; the basilisk gains a +2 bonus to attack.
 - **Mirrors:** The reflection of a basilisk is harmless. Fighting by looking in a mirror incurs a -1 penalty to attack. If a basilisk sees its own reflection (2-in-6 chance), it must save or be petrified.

--- a/7. Monsters/Monster Stats/Djinni (Lesser).md
+++ b/7. Monsters/Monster Stats/Djinni (Lesser).md
@@ -23,7 +23,7 @@ Highly magical, free-willed, intelligent beings from the elemental plane of air.
 
 - **Magic powers:** Each can be used three times per day:
 
-  - **Whirlwind form:** 5 rounds to transform (or change back). 70’ tall, 20’ wide at top, 10’ wide at base. Moves at 120’ (40’). 2d6 damage to all in the path. Creatures with less than 2HD swept aside (**save vs. death**).
+  - **Whirlwind form:** 5 rounds to transform (or change back). 70’ tall, 20’ wide at top, 10’ wide at base. Moves at 120’ (40’). 2d6 damage to all in the path. Creatures with less than 2HD swept aside (**save versus death**).
   - **Gaseous form**
   - **Invisibility**
   - **Illusion:** Visual and audial. No concentration is required. Remains until touched or dispelled.

--- a/7. Monsters/Monster Stats/Fish, Giant.md
+++ b/7. Monsters/Monster Stats/Fish, Giant.md
@@ -89,7 +89,7 @@ Spiny fish with lumpy, rock-like skin. Live in saltwater shallows. Normally pass
 
 - **Camouflage:** 70% chance of being mistaken for a rock or coral formation.
 - **Grasping:** If mistaken for a rock and grasped, all 4 spines automatically hit.
-- **Poison:** Causes death (**save vs poison**).
+- **Poison:** Causes death (**save versus poison**).
 
 ## Giant Sturgeon
 

--- a/7. Monsters/Monster Stats/Killer Bee.md
+++ b/7. Monsters/Monster Stats/Killer Bee.md
@@ -21,7 +21,7 @@ Giant (1’ long) bees of aggressive temperament. Build hives underground.
 
 - **Aggressive:** Usually attack on sight. Always attack intruders within 30’ of their hive.
 - **Die after attacking:** On a successful sting attack, a killer bee dies.
-- **Poison:** Causes death (**save vs. poison**).
+- **Poison:** Causes death (**save versus poison**).
 - **Lodged stinger:** Inflicts 1 damage per round, as the stinger works its way in. A round can be spent to remove it.
 - **Queen:** A 2HD queen lives in the hive. The queen does not die when she stings.
 - **Guards:** At least 10 bees (4 or more of which have 1HD) remain in or near the hive to protect the queen.

--- a/7. Monsters/Monster Stats/Purple Worm.md
+++ b/7. Monsters/Monster Stats/Purple Worm.md
@@ -20,5 +20,5 @@ Gigantic, slimy worms with bodies 100’ long and 8–10’ thick. Bore tunnels 
 ------
 
 - **Swallow whole:** A bite attack roll of 20, or 4 or more than the target number required, indicates that a human-sized (or smaller) victim is swallowed. Inside the worm’s belly: suffer 3d6 damage per round (until the worm dies); may attack with sharp weapons at -4 to hit; body digested in 6 turns after death.
-- **Poison:** Causes death (**save vs. poison**).
+- **Poison:** Causes death (**save versus poison**).
 - **In restricted spaces:** May not always be able to bite and sting at once.

--- a/7. Monsters/Monster Stats/Scorpion, Giant.md
+++ b/7. Monsters/Monster Stats/Scorpion, Giant.md
@@ -20,5 +20,5 @@ Huge arachnids, as big as a small horse, with pincers and deadly stingers. Dwell
 ------
 
 - **Aggressive:** Normally attack on sight.
-- **Poison:** Causes death (**save vs. poison**).
+- **Poison:** Causes death (**save versus poison**).
 - **Grab and sting:** +2 bonus to sting attack, if a claw hits.

--- a/7. Monsters/Monster Stats/Snake.md
+++ b/7. Monsters/Monster Stats/Snake.md
@@ -50,7 +50,7 @@ Dwell in all but the most extreme climes. Will usually only attack if cornered o
 
 - **Infravision:** 60’. (Pits in the head allow heat sense.)
 - **Initiative:** Always gains initiative (no roll), due to special senses.
-- **Poison:** Causes death (**save vs poison**).
+- **Poison:** Causes death (**save versus poison**).
 
 ## Rock Python
 
@@ -97,7 +97,7 @@ Dwell in all but the most extreme climes. Will usually only attack if cornered o
 ------
 
 - **Pinprick bite:** 50% chance of going unnoticed.
-- **Poison:** Slow acting: effects felt after 1d4+2 turns. **Save vs poison** or die 1 turn later. At this point, the *neutralize poison* spell has a 25% chance of not working.
+- **Poison:** Slow acting: effects felt after 1d4+2 turns. **Save versus poison** or die 1 turn later. At this point, the *neutralize poison* spell has a 25% chance of not working.
 - **Larger individuals:** Sea snakes with more than 3 HD may be encountered. They are 6’ long for every 3 HD.
 
 ## Spitting Cobra
@@ -121,5 +121,5 @@ Dwell in all but the most extreme climes. Will usually only attack if cornered o
 
 ------
 
-- **Blinding spit:** Range: 6’. A hit causes permanent blindness (**save vs poison**).
+- **Blinding spit:** Range: 6’. A hit causes permanent blindness (**save versus poison**).
 - **Poison:** Causes death in 1d10 turns (**save versus poison**).

--- a/7. Monsters/Monster Stats/Spider, Giant.md
+++ b/7. Monsters/Monster Stats/Spider, Giant.md
@@ -71,6 +71,6 @@
 
 ------
 
-- **Poison:** **Save vs poison** or dance for 2d6 turns (suffering from painful, jerking spasms that resemble a macabre dance).
+- **Poison:** **Save versus poison** or dance for 2d6 turns (suffering from painful, jerking spasms that resemble a macabre dance).
 - **Onlookers:** Viewers of one affected by the poison must **save versus spells** or begin dancing in the same fashion, for as long as the poisoned victim.
 - **Dancing:** Those affected suffer a -4 penalty to attack rolls and AC. After 5 turns of dancing, they become exhausted: fall to the ground, helpless.

--- a/7. Monsters/Monster Stats/Vampire.md
+++ b/7. Monsters/Monster Stats/Vampire.md
@@ -44,7 +44,7 @@ Greatly feared undead monsters that live by drinking the blood of mortals. Dwell
 
 - **Vulnerabilities:**
 
-  - **Garlic:** Odour repels: save vs poison or unable to attack this round.
+  - **Garlic:** Odour repels: save versus poison or unable to attack this round.
   - **Holy symbols:** If presented, will keep a vampire at bay (10’). May attack wielder from another direction.
   - **Running water:** Cannot cross (in any form), except by a bridge or carried inside a coffin.
   - **Mirrors:** Avoid; do not cast a reflection.

--- a/7. Monsters/Monster Stats/Wyvern.md
+++ b/7. Monsters/Monster Stats/Wyvern.md
@@ -19,4 +19,4 @@ Winged, two-legged, dragon-like monsters with a long tail tipped with a venomous
 
 ------
 
-- **Poison:** Causes death (**save vs. poison**).
+- **Poison:** Causes death (**save versus poison**).


### PR DESCRIPTION
The source Old School Essentials SRD uses all of "vs", "vs." and "versus". See for example the Basilisk entry, where the "Petrifying touch" list item uses "vs" and the next list item uses "versus".

Here in the Monster Stats files, it seems reasonable to consistently use the unabbreviated "versus" everywhere.